### PR TITLE
pr-f39-update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
+output/
 logs/
+/cluster.env
 __pycache__
 */__pycache__/
 .DS_Store

--- a/Dockerfile-airflow
+++ b/Dockerfile-airflow
@@ -1,4 +1,4 @@
-FROM  apache/airflow:2.3.2
+FROM  docker.io/apache/airflow:2.8.3
 
 USER root
 
@@ -91,7 +91,7 @@ RUN mkdir /hadoop-data
 # SPARK
 # --------------------------------------------------------
 
-ENV SPARK_VERSION spark-3.5.0
+ENV SPARK_VERSION spark-3.5.1
 ENV SPARK_URL https://downloads.apache.org/spark/${SPARK_VERSION}/${SPARK_VERSION}-bin-hadoop3.tgz
 ENV SPARK_HOME=/opt/$SPARK_VERSION
 ENV PATH $SPARK_HOME/bin:$PATH

--- a/Dockerfile-hadoop
+++ b/Dockerfile-hadoop
@@ -1,6 +1,6 @@
-FROM openjdk:11-jdk AS jdk
+FROM docker.io/openjdk:11-jdk AS jdk
 
-FROM python:3.11
+FROM docker.io/python:3.11
 
 USER root
 
@@ -60,7 +60,7 @@ COPY conf/yarn-site.xml $HADOOP_CONF_DIR/yarn-site.xml
 # SPARK
 # --------------------------------------------------------
 
-ENV SPARK_VERSION spark-3.5.0
+ENV SPARK_VERSION spark-3.5.1
 ENV SPARK_URL https://downloads.apache.org/spark/${SPARK_VERSION}/${SPARK_VERSION}-bin-hadoop3.tgz
 ENV SPARK_HOME=/opt/$SPARK_VERSION
 ENV PATH $SPARK_HOME/bin:$PATH

--- a/Readme.md
+++ b/Readme.md
@@ -13,8 +13,10 @@ This is just for learning intention, not recomended for production. Use Hortonwo
 ## Kick-off Cluster
 
 1. Clone this repos to your project directory, and `cd hadoop-docker`
-2. If you are in Linux/MAC Just simply run `./run_cluster.sh`
-3. If you are in Windows try run this command `docker build -t hadoop-base:3.3.6 . && docker-compose up`
+2. `cp cluster-template.env cluster.env`
+3. Edit `cluster.env` (choose docker or podman)
+4. If you are in Linux/MAC Just simply run `./run_cluster.sh`
+5. If you are in Windows try run this command `docker build -t localhost/hadoop-base:3.3.6 . && docker-compose up`
 
 ## How to run MapReduce Job
 
@@ -44,6 +46,14 @@ hadoop jar /opt/hadoop-3.3.6/share/hadoop/tools/lib/hadoop-streaming-3.3.6.jar -
 ## End to end step by step to kick-off Airflow, Spark Cluster and Hadoop Cluster
 
 Please start everything from `run_cluster.sh` because the base image created from this step
+
+## Known problems
+
+* Not for production use, as authentication and security are missing.
+* OCI container images do not support `HEALTHCHECK`. Hence podman ignores this.
+* WARNING: HADOOP_PREFIX has been replaced by HADOOP_HOME. Using value of HADOOP_PREFIX.
+* `db init` is deprecated.  Use `db migrate` instead to migrate the db and/or 
+  airflow connections create-default-connections to create the default connections.
 
 ## To Do
 

--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -1,11 +1,11 @@
-FROM hadoop-base:3.3.6
+FROM localhost/hadoop-base:3.3.6
 
 # Never prompt the user for choices on installation/configuration of packages
 ENV DEBIAN_FRONTEND noninteractive
 ENV TERM linux
 
 # Airflow
-ARG AIRFLOW_VERSION=2.3.2
+ARG AIRFLOW_VERSION=2.8.3
 ARG AIRFLOW_USER_HOME=/home/airflow
 ARG AIRFLOW_DEPS=""
 ARG PYTHON_DEPS=""
@@ -61,7 +61,7 @@ RUN set -ex \
     && pip install cython \
     && pip install apache-airflow[crypto,celery,postgres,jdbc,mysql]==${AIRFLOW_VERSION} \
     && pip install 'redis==3.2' \
-    && pip install SQLAlchemy Flask-SQLAlchemy==2.4.4 \
+    && pip install SQLAlchemy Flask-SQLAlchemy \
     && if [ -n "${PYTHON_DEPS}" ]; then pip install ${PYTHON_DEPS}; fi \
     && apt-get purge --auto-remove -yqq $buildDeps \
     && apt-get autoremove -yqq --purge \

--- a/airflow/entrypoint.sh
+++ b/airflow/entrypoint.sh
@@ -108,9 +108,16 @@ if [ "$AIRFLOW__CORE__EXECUTOR" = "CeleryExecutor" ]; then
   wait_for_port "Redis" "$REDIS_HOST" "$REDIS_PORT"
 fi
 
+TEST=`airflow users list`
+if [ "$TEST" = "No data found" ]; then
+  airflow db init \
+  && airflow db upgrade \
+  && airflow users create --role Admin --username airflow --password airflow \
+    --email airflow@airflow.com --firstname airflow --lastname airflow;
+fi
+
 case "$1" in
   webserver)
-    airflow initdb
     if [ "$AIRFLOW__CORE__EXECUTOR" = "LocalExecutor" ] || [ "$AIRFLOW__CORE__EXECUTOR" = "SequentialExecutor" ]; then
       # With the "Local" and "Sequential" executors it should all run in one container.
       airflow scheduler &

--- a/airflow/run_airflow.sh
+++ b/airflow/run_airflow.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
-docker build -t airflow-hadoop-base:3.3.6 .
+source ../cluster.env
+
+$DOCKER build -t localhost/airflow-hadoop-base:3.3.6 .

--- a/cluster-template.env
+++ b/cluster-template.env
@@ -1,0 +1,2 @@
+DOCKER=podman
+DOCKER_COMPOSE=podman-compose

--- a/dags/avg_product_price.py
+++ b/dags/avg_product_price.py
@@ -1,5 +1,6 @@
 from airflow import DAG
 from airflow.operators.dummy import DummyOperator
+from airflow.operators.bash import BashOperator
 from airflow.contrib.operators.spark_submit_operator import SparkSubmitOperator
 from datetime import datetime, timedelta
 
@@ -16,8 +17,9 @@ default_args = {
 
 with DAG('avg_product_price', default_args=default_args, schedule_interval=None, catchup=False) as dag:
 
-    start = DummyOperator(
+    start = BashOperator(
         task_id='start',
+        bash_command='hadoop fs -mkdir -p hdfs://namenode:8020/user/root/input; hadoop fs -mkdir -p hdfs://namenode:8020/user/root/output; hadoop fs -copyFromLocal /hadoop-data/input/* hdfs://namenode:8020/user/root/input/; exit 0'
     )
 
     spark_submit = SparkSubmitOperator(
@@ -26,8 +28,9 @@ with DAG('avg_product_price', default_args=default_args, schedule_interval=None,
         application="/hadoop-data/map_reduce/spark/average_price.py"
     )
 
-    end = DummyOperator(
+    end = BashOperator(
         task_id='end',
+        bash_command='hadoop fs -copyToLocal -f hdfs://namenode:8020/user/root/output/* /home/airflow/output/; exit 0'
     )
 
     start >> spark_submit >> end

--- a/dags/lowest_rated_movies.py
+++ b/dags/lowest_rated_movies.py
@@ -1,5 +1,6 @@
 from airflow import DAG
 from airflow.operators.dummy import DummyOperator
+from airflow.operators.bash import BashOperator
 from airflow.contrib.operators.spark_submit_operator import SparkSubmitOperator
 from datetime import datetime, timedelta
 
@@ -16,8 +17,9 @@ default_args = {
 
 with DAG('lowest_rated_movies', default_args=default_args, schedule_interval=None, catchup=False) as dag:
 
-    start = DummyOperator(
+    start = BashOperator(
         task_id='start',
+        bash_command='hadoop fs -mkdir -p hdfs://namenode:8020/user/root/input; hadoop fs -mkdir -p hdfs://namenode:8020/user/root/output; hadoop fs -copyFromLocal /hadoop-data/input/* hdfs://namenode:8020/user/root/input/; exit 0'
     )
 
     spark_submit = SparkSubmitOperator(

--- a/datanode/Dockerfile
+++ b/datanode/Dockerfile
@@ -1,6 +1,6 @@
 # build from hadoop-base:3.2.1
-# that we built before using docker build -t hadoop-base:3.3.6 .
-FROM hadoop-base:3.3.6
+# that we built before using docker build -t localhost/hadoop-base:3.3.6 .
+FROM localhost/hadoop-base:3.3.6
 
 HEALTHCHECK CMD curl -f http://localhost:9864/ || exit 1
 

--- a/docker-compose-airflow-hadoop.yml
+++ b/docker-compose-airflow-hadoop.yml
@@ -1,6 +1,6 @@
 version: "2.1"
 x-airflow-common: &airflow-common
-  image: ${AIRFLOW_IMAGE_NAME:-hadoop-base:3.3.6}
+  image: ${AIRFLOW_IMAGE_NAME:-docker.io/hadoop-base:3.3.6}
   environment:
     - AIRFLOW_HOME=/home/airflow
     - AIRFLOW__CORE_dags_folder=/home/airflow/dags
@@ -12,12 +12,12 @@ x-airflow-common: &airflow-common
     - AIRFLOW__CORE__LOAD_EXAMPLES=False
     - AIRFLOW__CORE__LOGGING_LEVEL=INFO
   volumes:
-    - ./output:/home/airflow/output
-    - ./dags:/home/airflow/dags
-    - ./plugins:/home/airflow/plugins
-    - ./logs:/home/airflow/logs
-    - ./data/:/hadoop-data/input
-    - ./map_reduce/:/hadoop-data/map_reduce
+    - ./output:/home/airflow/output:z
+    - ./dags:/home/airflow/dags:z
+    - ./plugins:/home/airflow/plugins:z
+    - ./logs:/home/airflow/logs:z
+    - ./data/:/hadoop-data/input:z
+    - ./map_reduce/:/hadoop-data/map_reduce:z
   depends_on:
     - postgres
   networks:
@@ -25,13 +25,14 @@ x-airflow-common: &airflow-common
 
 services:
   namenode:
+    image: localhost/namenode
     build: ./namenode
     container_name: namenode
     volumes:
-      - hadoop_namenode:/hadoop/dfs/name
-      - ./data/:/hadoop-data/input
-      - ./map_reduce/:/hadoop-data/map_reduce
-      - ./requirements.txt:/hadoop-data/requirements.txt
+      - hadoop_namenode:/hadoop/dfs/name:z
+      - ./data/:/hadoop-data/input:z
+      - ./map_reduce/:/hadoop-data/map_reduce:z
+      - ./requirements.txt:/hadoop-data/requirements.txt:z
     environment:
       - CLUSTER_NAME=test
     env_file:
@@ -42,6 +43,7 @@ services:
       - hadoop_network
 
   resourcemanager:
+    image: localhost/resourcemanager
     build: ./resourcemanager
     container_name: resourcemanager
     restart: on-failure
@@ -49,7 +51,7 @@ services:
       - namenode
       - datanode1
       - datanode2
-      - datanode3
+      # - datanode3
     env_file:
       - ./hadoop.env
     ports:
@@ -58,6 +60,7 @@ services:
       - hadoop_network
 
   historyserver:
+    image: localhost/historyserver
     build: ./historyserver
     container_name: historyserver
     depends_on:
@@ -65,7 +68,7 @@ services:
       - datanode1
       - datanode2
     volumes:
-      - hadoop_historyserver:/hadoop/yarn/timeline
+      - hadoop_historyserver:/hadoop/yarn/timeline:z
     env_file:
       - ./hadoop.env
     ports:
@@ -74,6 +77,7 @@ services:
       - hadoop_network
 
   nodemanager1:
+    image: localhost/nodemanager
     build: ./nodemanager
     container_name: nodemanager1
     depends_on:
@@ -88,43 +92,46 @@ services:
       - hadoop_network
 
   datanode1:
+    image: localhost/datanode
     build: ./datanode
     container_name: datanode1
     depends_on:
       - namenode
     volumes:
-      - hadoop_datanode1:/hadoop/dfs/data
+      - hadoop_datanode1:/hadoop/dfs/data:z
     env_file:
       - ./hadoop.env
     networks:
       - hadoop_network
 
   datanode2:
+    image: localhost/datanode
     build: ./datanode
     container_name: datanode2
     depends_on:
       - namenode
     volumes:
-      - hadoop_datanode2:/hadoop/dfs/data
+      - hadoop_datanode2:/hadoop/dfs/data:z
     env_file:
       - ./hadoop.env
     networks:
       - hadoop_network
 
-  datanode3:
-    build: ./datanode
-    container_name: datanode3
-    depends_on:
-      - namenode
-    volumes:
-      - hadoop_datanode3:/hadoop/dfs/data
-    env_file:
-      - ./hadoop.env
-    networks:
-      - hadoop_network
+  # datanode3:
+  #   image: localhost/datanode
+  #   build: ./datanode
+  #   container_name: datanode3
+  #   depends_on:
+  #     - namenode
+  #   volumes:
+  #     - hadoop_datanode3:/hadoop/dfs/data:z
+  #   env_file:
+  #     - ./hadoop.env
+  #   networks:
+  #     - hadoop_network
 
   postgres:
-    image: postgres:13
+    image: docker.io/postgres:13
     environment:
       - POSTGRES_USER=airflow
       - POSTGRES_PASSWORD=airflow
@@ -135,14 +142,14 @@ services:
     networks:
       - hadoop_network
 
-  airflow-init:
-    <<: *airflow-common
-    container_name: airflow_init
-    entrypoint: /bin/bash
-    command:
-      - -c
-      - airflow users list || ( airflow db init && airflow db upgrade && airflow users create --role Admin --username airflow --password airflow --email airflow@airflow.com --firstname airflow --lastname airflow )
-    restart: on-failure
+  # airflow-init:
+  #   <<: *airflow-common
+  #   container_name: airflow_init
+  #   entrypoint: /bin/bash
+  #   command:
+  #     - -c
+  #     - airflow users list || ( airflow db init && airflow db upgrade && airflow users create --role Admin --username airflow --password airflow --email airflow@airflow.com --firstname airflow --lastname airflow )
+  #   restart: on-failure
 
   airflow-webserver:
     <<: *airflow-common
@@ -162,7 +169,7 @@ volumes:
   hadoop_namenode:
   hadoop_datanode1:
   hadoop_datanode2:
-  hadoop_datanode3:
+  # hadoop_datanode3:
   hadoop_historyserver:
 
 

--- a/docker-compose-airflow.yml
+++ b/docker-compose-airflow.yml
@@ -1,6 +1,6 @@
 version: "2.1"
 x-airflow-common: &airflow-common
-  image: ${AIRFLOW_IMAGE_NAME:-airflow-hadoop-base:3.3.6}
+  image: ${AIRFLOW_IMAGE_NAME:-localhost/airflow-hadoop-base:3.3.6}
   environment:
     - AIRFLOW_HOME=/home/airflow
     - AIRFLOW__CORE_dags_folder=/home/airflow/dags
@@ -12,12 +12,12 @@ x-airflow-common: &airflow-common
     - AIRFLOW__CORE__LOAD_EXAMPLES=False
     - AIRFLOW__CORE__LOGGING_LEVEL=INFO
   volumes:
-    - ./output:/home/airflow/output
-    - ./dags:/home/airflow/dags
-    - ./plugins:/home/airflow/plugins
-    - ./logs:/home/airflow/logs
-    - ./data/:/hadoop-data/input
-    - ./map_reduce/:/hadoop-data/map_reduce
+    - ./output:/home/airflow/output:z
+    - ./dags:/home/airflow/dags:z
+    - ./plugins:/home/airflow/plugins:z
+    - ./logs:/home/airflow/logs:z
+    - ./data/:/hadoop-data/input:z
+    - ./map_reduce/:/hadoop-data/map_reduce:z
   depends_on:
     - postgres
   networks:
@@ -25,7 +25,7 @@ x-airflow-common: &airflow-common
 
 services:
   postgres:
-    image: postgres:13
+    image: docker.io/postgres:13
     environment:
       - POSTGRES_USER=airflow
       - POSTGRES_PASSWORD=airflow
@@ -36,14 +36,14 @@ services:
     networks:
       - hadoop_network
 
-  airflow-init:
-    <<: *airflow-common
-    container_name: airflow_init
-    entrypoint: /bin/bash
-    command:
-      - -c
-      - airflow users list || ( airflow db init && airflow db upgrade && airflow users create --role Admin --username airflow --password airflow --email airflow@airflow.com --firstname airflow --lastname airflow )
-    restart: on-failure
+  # airflow-init:
+  #   <<: *airflow-common
+  #   container_name: airflow_init
+  #   entrypoint: /bin/bash
+  #   command:
+  #     - -c
+  #     - airflow users list || ( airflow db init && airflow db upgrade && airflow users create --role Admin --username airflow --password airflow --email airflow@airflow.com --firstname airflow --lastname airflow )
+  #   restart: on-failure
 
   airflow-webserver:
     <<: *airflow-common

--- a/docker-compose-hadoop.yml
+++ b/docker-compose-hadoop.yml
@@ -2,13 +2,14 @@ version: "2.1"
 
 services:
   namenode:
+    image: localhost/namenode
     build: ./namenode
     container_name: namenode
     volumes:
-      - hadoop_namenode:/hadoop/dfs/name
-      - ./data/:/hadoop-data/input
-      - ./map_reduce/:/hadoop-data/map_reduce
-      - ./requirements.txt:/hadoop-data/requirements.txt
+      - hadoop_namenode:/hadoop/dfs/name:z
+      - ./data/:/hadoop-data/input:z
+      - ./map_reduce/:/hadoop-data/map_reduce:z
+      - ./requirements.txt:/hadoop-data/requirements.txt:z
     environment:
       - CLUSTER_NAME=test
     env_file:
@@ -20,6 +21,7 @@ services:
       - hadoop_network
 
   resourcemanager:
+    image: localhost/resourcemanager
     build: ./resourcemanager
     container_name: resourcemanager
     restart: on-failure
@@ -27,7 +29,7 @@ services:
       - namenode
       - datanode1
       - datanode2
-      - datanode3
+      # - datanode3
     env_file:
       - ./hadoop.env
     ports:
@@ -36,6 +38,7 @@ services:
       - hadoop_network
 
   historyserver:
+    image: localhost/historyserver
     build: ./historyserver
     container_name: historyserver
     depends_on:
@@ -43,7 +46,7 @@ services:
       - datanode1
       - datanode2
     volumes:
-      - hadoop_historyserver:/hadoop/yarn/timeline
+      - hadoop_historyserver:/hadoop/yarn/timeline:z
     env_file:
       - ./hadoop.env
     ports:
@@ -52,6 +55,7 @@ services:
       - hadoop_network
 
   nodemanager1:
+    image: localhost/nodemanager
     build: ./nodemanager
     container_name: nodemanager1
     depends_on:
@@ -66,35 +70,38 @@ services:
       - hadoop_network
 
   datanode1:
+    image: localhost/datanode
     build: ./datanode
     container_name: datanode1
     depends_on:
       - namenode
     volumes:
-      - hadoop_datanode1:/hadoop/dfs/data
+      - hadoop_datanode1:/hadoop/dfs/data:z
     env_file:
       - ./hadoop.env
     networks:
       - hadoop_network
 
   datanode2:
+    image: localhost/datanode
     build: ./datanode
     container_name: datanode2
     depends_on:
       - namenode
     volumes:
-      - hadoop_datanode2:/hadoop/dfs/data
+      - hadoop_datanode2:/hadoop/dfs/data:z
     env_file:
       - ./hadoop.env
     networks:
       - hadoop_network
   # datanode3:
+  #   image: localhost/datanode
   #   build: ./datanode
   #   container_name: datanode3
   #   depends_on:
   #     - namenode
   #   volumes:
-  #     - hadoop_datanode3:/hadoop/dfs/data
+  #     - hadoop_datanode3:/hadoop/dfs/data:z
   #   env_file:
   #     - ./hadoop.env
   #   networks:
@@ -103,8 +110,8 @@ services:
 volumes:
   hadoop_namenode:
   hadoop_datanode1:
-  hadoop_datanode2: # hadoop_datanode3:
-
+  hadoop_datanode2: 
+  # hadoop_datanode3:
   hadoop_historyserver:
 
 

--- a/historyserver/Dockerfile
+++ b/historyserver/Dockerfile
@@ -1,6 +1,7 @@
 # build from hadoop-base:3.3.6 if your architectur is AMD64
-# that we built before using docker build -t hadoop-base:3.3.6 .
-FROM bde2020/hadoop-base:2.0.0-hadoop3.2.1-java8
+FROM localhost/hadoop-base:3.3.6
+# that we built before using docker build -t localhost/hadoop-base:3.3.6 .
+# FROM docker.io/bde2020/hadoop-base:2.0.0-hadoop3.2.1-java8
 
 HEALTHCHECK CMD curl -f http://localhost:8188/ || exit 1
 

--- a/namenode/Dockerfile
+++ b/namenode/Dockerfile
@@ -1,6 +1,6 @@
 # build from hadoop-base:3.2.1
 # that we built before using docker build -t hadoop-base:3.2.1 .
-FROM hadoop-base:3.3.6
+FROM localhost/hadoop-base:3.3.6
 
 HEALTHCHECK CMD curl -f http://localhost:9870/ || exit 1
 

--- a/nodemanager/Dockerfile
+++ b/nodemanager/Dockerfile
@@ -1,6 +1,6 @@
 # build from hadoop-base:3.2.1
-# that we built before using docker build -t hadoop-base:3.2.1 .
-FROM hadoop-base:3.3.6
+# that we built before using docker build -t localhost/hadoop-base:3.2.1 .
+FROM localhost/hadoop-base:3.3.6
 
 HEALTHCHECK CMD curl -f http://localhost:8042/ || exit 1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ pyyaml = "^6.0.1"
 py4j = "^0.10.9.7"
 numpy = "^1.26.3"
 pandas = "^2.2.0"
-pyspark = "^3.5.0"
+pyspark = "^3.5.1"
 apache-airflow-providers-apache-spark = "^4.7.1"
 
 

--- a/resourcemanager/Dockerfile
+++ b/resourcemanager/Dockerfile
@@ -1,6 +1,6 @@
 # build from hadoop-base:3.2.1
-# that we built before using docker build -t hadoop-base:3.2.1 .
-FROM hadoop-base:3.3.6
+# that we built before using docker build -t localhost/hadoop-base:3.2.1 .
+FROM localhost/hadoop-base:3.3.6
 
 HEALTHCHECK CMD curl -f http://localhost:8088/ || exit 1
 

--- a/run_cluster.sh
+++ b/run_cluster.sh
@@ -1,19 +1,24 @@
 #!/bin/bash
 
+source cluster.env
+
+# containers write into logs and output
+chmod -R a+w logs output
+
 # create new network
-docker network create hadoop_network
+$DOCKER network create hadoop_network
 
 # build docker image with image name hadoop-base:3.3.6
-docker build -t hadoop-base:3.3.6 -f Dockerfile-hadoop .
+$DOCKER build -t localhost/hadoop-base:3.3.6 -f Dockerfile-hadoop .
 # running image to container, -d to run it in daemon mode
-docker-compose -f docker-compose-hadoop.yml up -d
+$DOCKER_COMPOSE -f docker-compose-hadoop.yml up -d
 
 # Run Airflow Cluster
 if [[ "$PWD" != "airflow" ]]; then
   cd airflow && ./run_airflow.sh && cd ..
 fi
 
-docker-compose -f docker-compose-airflow.yml up -d
+$DOCKER_COMPOSE -f docker-compose-airflow.yml up -d
 
 # Run Spark Cluster
 if [[ "$PWD" != "spark" ]]; then

--- a/spark/Dockerfile
+++ b/spark/Dockerfile
@@ -1,5 +1,5 @@
 # builder step used to download and configure spark environment
-FROM hadoop-base:3.3.6 AS builder
+FROM localhost/hadoop-base:3.3.6 AS builder
 
 WORKDIR $SPARK_HOME
 

--- a/spark/docker-compose.yml
+++ b/spark/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.3"
 
 services:
   spark-master:
-    image: spark-base:3.5.0
+    image: localhost/spark-base:3.5.1
     ports:
       - 9090:8081
       - 7077:7077
@@ -17,7 +17,7 @@ services:
     command: /bin/sh -c "./start-spark.sh"
 
   spark-worker-a:
-    image: spark-base:3.5.0
+    image: localhost/spark-base:3.5.1
     ports:
       - 9091:8081
       - 7000:7000
@@ -39,7 +39,7 @@ services:
     command: /bin/sh -c "./start-spark.sh"
 
   spark-worker-b:
-    image: spark-base:3.5.0
+    image: localhost/spark-base:3.5.1
     ports:
       - 9092:8081
       - 7001:7000

--- a/spark/start-cluster.sh
+++ b/spark/start-cluster.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 
-docker build -t spark-base:3.5.0 .
-docker-compose up -d
+source ../cluster.env
+
+$DOCKER build -t localhost/spark-base:3.5.1 .
+$DOCKER_COMPOSE up -d

--- a/spark/start-spark.sh
+++ b/spark/start-spark.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source ../cluster.env
+
 . "$SPARK_HOME/bin/load-spark-env.sh"
 # When the spark work_load is master run class org.apache.spark.deploy.master.Master
 if [ "$SPARK_WORKLOAD" == "master" ];

--- a/stop_cluster.sh
+++ b/stop_cluster.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 
+source cluster.env
+
 # Stop Airflow
-docker-compose -f docker-compose-airflow.yml down
+$DOCKER_COMPOSE -f docker-compose-airflow.yml down
 # Stop Hadoop
-docker-compose -f docker-compose-hadoop.yml down
+$DOCKER_COMPOSE -f docker-compose-hadoop.yml down
 
 # Run Spark Cluster
 if [[ "$PWD" != "spark" ]]; then
-  cd spark && docker-compose down && cd ..
+  cd spark && $DOCKER_COMPOSE down && cd ..
 fi
 
 echo "All services stoped"


### PR DESCRIPTION
Dear @ayyoubmaulana,

thank you for publishing a starting point to explore hadoop/spark/airflow!

I played around with it on my Fedora 39 PC and had to do small changes to get it running:

* spark update from 3.5.0 to 3.5.1
* airflow update from 2.3.2 to 2.8.3
* now works with docker/docker-compose (rootless) and podman/podman-compose (configurable)
* fixed the 2 airflow DAG examples
  + ensure that input stuff is copied to hdfs on start
  + ensure that result is copied from hdfs to output on end
* works on Fedora 39 (added SELinux support)

I would appreciate if you consider merging.

Kind regards,
aanno